### PR TITLE
Updated Discord link to active invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Yearn ecosystem is controlled by YFI token holders who submit and vote on pr
 
 Governance Forum [https://gov.yearn.finance/](https://gov.yearn.finance/)
 
-Discord [https://discord.gg/JdbkVN](https://discord.gg/JdbkVN)
+Discord [https://discord.gg/GcjxhWR](https://discord.gg/GcjxhWR)
 
 Telegram [https://t.me/yearnfinance](https://t.me/yearnfinance)
 


### PR DESCRIPTION
Previous link gave "Invite Invalid" message