### PR TITLE
Fix Clarify Strategy Management

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -4,7 +4,7 @@ YFI holders govern the Yearn ecosystem and are eligble to receive a portion of p
 
 In order to claim profits, YFI holders stake their tokens into the [Governance contract](https://etherscan.io/token/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e?a=0xba37b002abafdd8e89a1995da52740bbc013d992). Profits are periodically sent to this contract from the Yearn [Treasury Vault](https://etherscan.io/address/0x93a62da5a14c80f265dabc077fcee437b1a0efde#tokentxns), which temporarily holds profits before distribution to stakeholders. Profits are sent to the Governance contract after the Treasury Vault has accrued a \$500,000 reserve; this reserve is used to pay for various operational expenses, including developer compensation and community grants. The amount retained in the Treasury contract before profits are sent to the Governance contract are subject to change by YFI holders.
 
-In order to vote on proposal changes to the ecosystem YFI holders must be staked in the governance contract. Stakeholders are _**u\***\_nable to withdraw_\*\_ their deposits for 72 hours after voting. They are also unable to claim their share of accrued, but undistributed profits, unless they have voted in a recent proposal. Profits are distributed as yCRV tokens.
+In order to vote on proposal changes to the ecosystem YFI holders must be staked in the governance contract. Stakeholders are **_unable to withdraw_** their deposits for 72 hours after voting. They are also unable to claim their share of accrued, but undistributed profits, unless they have voted in a recent proposal. Profits are distributed as yCRV tokens.
 
 The staking portal simplifies this process and can be found [here](https://ygov.finance/staking).
 


### PR DESCRIPTION
- Vault Management seems to have been duplicated twice, it's likely the second instance is referring to Strategy management 
- At the beginning of the Governance section it states `Governance manages the Vaults, Controller, and Strategies by calling functions on these contracts.` which would imply in the Strategy Management section that `approveStrategy()` and `revokeStrategy()` live on the Strategy contract. Clarified to mention that these functions are on the Controller. 