### PR TITLE
Delete Schema Diagrams stub page 

### DIFF
--- a/developers/schema-diagrams.md
+++ b/developers/schema-diagrams.md
@@ -1,5 +1,0 @@
-# Schema Diagrams
-
-{% hint style="info" %}
-This doc is currently in-progress and planned for publication before October 1.
-{% endhint %}


### PR DESCRIPTION
That content has already been added on the Vaults Overview page