### PR TITLE
Add yearn team page

### DIFF
--- a/additional-resources/team.md
+++ b/additional-resources/team.md
@@ -1,0 +1,38 @@
+# Team
+
+## Ops
+
+| Team Member | Twitter | Github |
+| :--- | :--- | :--- |
+| [@banteg](https://gov.yearn.finance/u/banteg) | [@bantg](https://twitter.com/bantg) | [@banteg](https://github.com/banteg) |
+| [@milkyklim](https://gov.yearn.finance/u/milkyklim) | [@milkyklim](https://twitter.com/milkyklim) | [@milkyklim](https://github.com/milkyklim) |
+| [@tracheopteryx](https://gov.yearn.finance/u/tracheopteryx) | [@tracheopteryx](https://twitter.com/tracheopteryx) | [@tracheopteryx](https://github.com/tracheopteryx) |
+
+## Protocol and Development
+
+| Team Member | Twitter | Github |
+| :--- | :--- | :--- |
+| @AndreCronjeTech \(founder\) | [@AndreCronjeTech](https://twitter.com/andrecronjetech) | [@andrecronje](https://github.com/andrecronje) |
+| [@fubuloubu](https://gov.yearn.finance/u/fubuloubu) | [@fubuloubu](https://twitter.com/fubuloubu) | [@fubuloubu](https://github.com/fubuloubu) |
+| [@x48](https://gov.yearn.finance/u/x48) | [@x48\_crypto](https://twitter.com/x48_crypto) | [@x48-crypto](https://github.com/x48-crypto/) |
+| [@doug](https://gov.yearn.finance/u/doug) |  |  |
+| [@luciano](https://gov.yearn.finance/u/luciano) |  |  |
+
+## Academic "Public Good"
+
+| Team Member | Twitter | Github |
+| :--- | :--- | :--- |
+| [@orbxball](https://gov.yearn.finance/u/orbxball) | N/A | [@orbxball](https://github.com/orbxball) |
+
+## Communications
+
+| Team Member | Twitter | Github |
+| :--- | :--- | :--- |
+| [@franklin](https://gov.yearn.finance/u/franklin) |  |  |
+| [@fameal](https://gov.yearn.finance/u/fameal) | [@fameal](https://twitter.com/fameal) | [@fameal](https://github.com/fameal) |
+| [@Dark](https://gov.yearn.finance/u/dark) |  |  |
+
+## Community Grants
+
+In addition to the team members above, Yearn Finance also rewards community contributions. Please see [Announcements](https://gov.yearn.finance/c/announcement/14) for grants awarded to team members.
+

--- a/additional-resources/team.md
+++ b/additional-resources/team.md
@@ -2,37 +2,36 @@
 
 ## Ops
 
-| Team Member | Twitter | Github |
-| :--- | :--- | :--- |
-| [@banteg](https://gov.yearn.finance/u/banteg) | [@bantg](https://twitter.com/bantg) | [@banteg](https://github.com/banteg) |
-| [@milkyklim](https://gov.yearn.finance/u/milkyklim) | [@milkyklim](https://twitter.com/milkyklim) | [@milkyklim](https://github.com/milkyklim) |
+| Team Member                                                 | Twitter                                             | Github                                             |
+| :---------------------------------------------------------- | :-------------------------------------------------- | :------------------------------------------------- |
+| [@banteg](https://gov.yearn.finance/u/banteg)               | [@bantg](https://twitter.com/bantg)                 | [@banteg](https://github.com/banteg)               |
+| [@milkyklim](https://gov.yearn.finance/u/milkyklim)         | [@milkyklim](https://twitter.com/milkyklim)         | [@milkyklim](https://github.com/milkyklim)         |
 | [@tracheopteryx](https://gov.yearn.finance/u/tracheopteryx) | [@tracheopteryx](https://twitter.com/tracheopteryx) | [@tracheopteryx](https://github.com/tracheopteryx) |
 
 ## Protocol and Development
 
-| Team Member | Twitter | Github |
-| :--- | :--- | :--- |
-| @AndreCronjeTech \(founder\) | [@AndreCronjeTech](https://twitter.com/andrecronjetech) | [@andrecronje](https://github.com/andrecronje) |
-| [@fubuloubu](https://gov.yearn.finance/u/fubuloubu) | [@fubuloubu](https://twitter.com/fubuloubu) | [@fubuloubu](https://github.com/fubuloubu) |
-| [@x48](https://gov.yearn.finance/u/x48) | [@x48\_crypto](https://twitter.com/x48_crypto) | [@x48-crypto](https://github.com/x48-crypto/) |
-| [@doug](https://gov.yearn.finance/u/doug) |  |  |
-| [@luciano](https://gov.yearn.finance/u/luciano) |  |  |
+| Team Member                                         | Twitter                                                 | Github                                         |
+| :-------------------------------------------------- | :------------------------------------------------------ | :--------------------------------------------- |
+| @AndreCronjeTech \(founder\)                        | [@AndreCronjeTech](https://twitter.com/andrecronjetech) | [@andrecronje](https://github.com/andrecronje) |
+| [@fubuloubu](https://gov.yearn.finance/u/fubuloubu) | [@fubuloubu](https://twitter.com/fubuloubu)             | [@fubuloubu](https://github.com/fubuloubu)     |
+| [@x48](https://gov.yearn.finance/u/x48)             | [@x48_crypto](https://twitter.com/x48_crypto)           | [@x48-crypto](https://github.com/x48-crypto/)  |
+| [@doug](https://gov.yearn.finance/u/doug)           |                                                         |                                                |
+| [@luciano](https://gov.yearn.finance/u/luciano)     |                                                         |                                                |
 
 ## Academic "Public Good"
 
-| Team Member | Twitter | Github |
-| :--- | :--- | :--- |
-| [@orbxball](https://gov.yearn.finance/u/orbxball) | N/A | [@orbxball](https://github.com/orbxball) |
+| Team Member                                       | Twitter | Github                                   |
+| :------------------------------------------------ | :------ | :--------------------------------------- |
+| [@orbxball](https://gov.yearn.finance/u/orbxball) | N/A     | [@orbxball](https://github.com/orbxball) |
 
 ## Communications
 
-| Team Member | Twitter | Github |
-| :--- | :--- | :--- |
-| [@franklin](https://gov.yearn.finance/u/franklin) |  |  |
-| [@fameal](https://gov.yearn.finance/u/fameal) | [@fameal](https://twitter.com/fameal) | [@fameal](https://github.com/fameal) |
-| [@Dark](https://gov.yearn.finance/u/dark) |  |  |
+| Team Member                                       | Twitter                               | Github                               |
+| :------------------------------------------------ | :------------------------------------ | :----------------------------------- |
+| [@franklin](https://gov.yearn.finance/u/franklin) |                                       |                                      |
+| [@fameal](https://gov.yearn.finance/u/fameal)     | [@fameal](https://twitter.com/fameal) | [@fameal](https://github.com/fameal) |
+| [@Dark](https://gov.yearn.finance/u/dark)         |                                       |                                      |
 
 ## Community Grants
 
 In addition to the team members above, Yearn Finance also rewards community contributions. Please see [Announcements](https://gov.yearn.finance/c/announcement/14) for grants awarded to team members.
-

--- a/additional-resources/team.md
+++ b/additional-resources/team.md
@@ -10,13 +10,13 @@
 
 ## Protocol and Development
 
-| Team Member                                         | Twitter                                                 | Github                                         |
-| :-------------------------------------------------- | :------------------------------------------------------ | :--------------------------------------------- |
-| @AndreCronjeTech \(founder\)                        | [@AndreCronjeTech](https://twitter.com/andrecronjetech) | [@andrecronje](https://github.com/andrecronje) |
-| [@fubuloubu](https://gov.yearn.finance/u/fubuloubu) | [@fubuloubu](https://twitter.com/fubuloubu)             | [@fubuloubu](https://github.com/fubuloubu)     |
-| [@x48](https://gov.yearn.finance/u/x48)             | [@x48_crypto](https://twitter.com/x48_crypto)           | [@x48-crypto](https://github.com/x48-crypto/)  |
-| [@doug](https://gov.yearn.finance/u/doug)           |                                                         |                                                |
-| [@luciano](https://gov.yearn.finance/u/luciano)     |                                                         |                                                |
+| Team Member                                               | Twitter                                                 | Github                                         |
+| :-------------------------------------------------------- | :------------------------------------------------------ | :--------------------------------------------- |
+| [@andre.cronje](https://gov.yearn.finance/u/andre.cronje) | [@AndreCronjeTech](https://twitter.com/andrecronjetech) | [@andrecronje](https://github.com/andrecronje) |
+| [@doug](https://gov.yearn.finance/u/doug)                 | [@doug_molinam](https://twitter.com/doug_molinam)       | [@dmolina79](https://github.com/dmolina79)     |
+| [@fubuloubu](https://gov.yearn.finance/u/fubuloubu)       | [@fubuloubu](https://twitter.com/fubuloubu)             | [@fubuloubu](https://github.com/fubuloubu)     |
+| [@luciano](https://gov.yearn.finance/u/luciano)           | [@lbertenasco](https://twitter.com/lbertenasco)         | [@lbertenasco](https://github.com/lbertenasco) |
+| [@x48](https://gov.yearn.finance/u/x48)                   | [@x48_crypto](https://twitter.com/x48_crypto)           | [@x48-crypto](https://github.com/x48-crypto/)  |
 
 ## Academic "Public Good"
 
@@ -26,12 +26,12 @@
 
 ## Communications
 
-| Team Member                                       | Twitter                               | Github                               |
-| :------------------------------------------------ | :------------------------------------ | :----------------------------------- |
-| [@franklin](https://gov.yearn.finance/u/franklin) |                                       |                                      |
-| [@fameal](https://gov.yearn.finance/u/fameal)     | [@fameal](https://twitter.com/fameal) | [@fameal](https://github.com/fameal) |
-| [@Dark](https://gov.yearn.finance/u/dark)         |                                       |                                      |
+| Team Member                                       | Twitter                                   | Github                               |
+| :------------------------------------------------ | :---------------------------------------- | :----------------------------------- |
+| [@franklin](https://gov.yearn.finance/u/franklin) | [@DeFiGod1](https://twitter.com/DeFiGod1) | N/A                                  |
+| [@fameal](https://gov.yearn.finance/u/fameal)     | [@fameal](https://twitter.com/fameal)     | [@fameal](https://github.com/fameal) |
+| [@Dark](https://gov.yearn.finance/u/dark)         | N/A                                       | N/A                                  |
 
 ## Community Grants
 
-In addition to the team members above, Yearn Finance also rewards community contributions. Please see [Announcements](https://gov.yearn.finance/c/announcement/14) for grants awarded to team members.
+In addition to the team members above, Yearn Finance also rewards community contributions. See [Announcements](https://gov.yearn.finance/c/announcement/14) for grants awarded to team members.


### PR DESCRIPTION
Fixes  #iearn-finance/iearn-finance#107 

- New team page under "Additional Resources" in docs 
- TODO: Missing Twitter and Github handles for some members with more generic names
- TODO: Link from main yearn.finance website (track progress on #iearn-finance/iearn-finance#107)

Note: This is edited using Gitbook GUI and it appears to have made markdown formatting changes across the board. Upon reviewing, most pages appear fine. We can cherry-pick just the `additional-resources/team.md` but it's probably better to use a markdown format that's compatible with Gitbook for easy edits.