### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,25 @@
 # Introduction to Yearn
-
-{% hint style="info" %}
-These docs are in active development by the Yearn community.
-{% endhint %}
-
-Yearn Finance is a suite of decentralized finance \(DeFi\) products focused on creating a simple way to generate high risk-adjusted returns for depositors of various assets via best-in-class lending protocols, liquidity pools, and community-made yield farming strategies on Ethereum.
+Yearn Finance is a suite of products in Decentralized Finance \(DeFi\) that at its core provides lending aggregation, yield generation, and insurance on the Ethereum blockchain. 
+The protocol is maintained and developed by various independent contributors within the cryptocurrency space. Management of the protocol is governed by YFI holders. Listed below are core products active in production, a brief description on the protocol's governance process, and links to active communication channels. 
 
 ## Core Products
 
 ### Vaults
-
-- Community-developed yield farming robots
-- yVaults follow a unique strategy that are designed to maximize the yield of the deposited asset and minimize risk.
+Capital pools that automatically generate yield based on opportunities present in the market. Vaults benefit users by socializing gas costs, automating the yield generation and rebalancing process, and automatically shifting capital as opportunities arise. End users also do not need to have a proficient knowledge of the underlying protocols involved or DeFi, thus the Vaults represent a passive-investing strategy.
 
 ### Earn
-
-- Yield-aware dynamic money markets that serve as building blocks for yVaults
-- Earn performs profit switching for lending providers, moving your funds between dydx, Aave, Compound autonomously.
+The first Yearn product was a lending aggregator. Funds are shifted between dYdX, AAVE, and Compound automatically as interest rates change between these protocols. Users can deposit to these lending aggregator smart contracts via the Earn page. This product completely optimizes the interest accrual process for end-users to ensure they are obtaining the highest interest rates at all times among the platforms specified above. 
 
 ### Zap
-
-- A tool that enables users to swap between various stablecoins and a basket of interest-bearing stablecoins \(yTokens\) or pools \(yCRV\)
-- Save on gas fees by Zapping directly into or out of Curve pools from the base assets.
+A tool that enables users to swap into and out of (known as "Zapping") several liquidity pools available on Curve.Finance. These pools benefit from the lending aggregators discussed above, as well as earning users trading fees by partcipating as Liquidity Providers (LPs) on Curve.Fi. Currently users can use five stablecoins (BUSD, DAI, USDC, USDT, TUSD) and "Zap" into one of two pools (y.curve.fi or busd.curve.f) on Curve. Alternatively, users can "Zap" out of these two Curve pools and into one of the five base stablecoins. 
 
 ### Cover
-
-- yInsure pooled insurance provides coverage against financial loss for various smart contracts and product offerings underwritten by Nexus Mutual.
+Insurance that enables users to obtain coverage against financial loss for various smart contracts and/or protcols on the Ethereum blockchain. Cover is underwritten by Nexus Mutual. 
 
 ## Governance
-
 The Yearn ecosystem is controlled by YFI token holders who submit and vote on proposals that govern the ecosystem. Proposals that meet quorum requirements \(&gt;20% of the tokens staked in the governance contract\) and generate a majority support \(&gt;50% of the vote\) are implemented by a 9 member multi-signature wallet. Changes must be signed by 6 out of the 9 wallet signers in order to be implemented. The members of the muliti-signature wallet were voted in by YFI holders and are subject to change from future governance votes. Please refer to our FAQ for [the list of the multisig signers](https://docs.yearn.finance/faq#who-are-the-9-multisig-signers).
 
-## Get Involved
-
+## Communication Channels
 Governance Forum [https://gov.yearn.finance/](https://gov.yearn.finance/)
 
 Discord [http://discord.yearn.finance](http://discord.yearn.finance)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
 # Introduction to Yearn
-Yearn Finance is a suite of products in Decentralized Finance \(DeFi\) that at its core provides lending aggregation, yield generation, and insurance on the Ethereum blockchain. 
-The protocol is maintained and developed by various independent contributors within the cryptocurrency space. Management of the protocol is governed by YFI holders. Listed below are core products active in production, a brief description on the protocol's governance process, and links to active communication channels. 
+
+Yearn Finance is a suite of products in Decentralized Finance \(DeFi\) that at its core provides lending aggregation, yield generation, and insurance on the Ethereum blockchain.
+The protocol is maintained and developed by various independent contributors within the cryptocurrency space. Management of the protocol is governed by YFI holders. Listed below are core products active in production, a brief description on the protocol's governance process, and links to active communication channels.
 
 ## Core Products
 
 ### Vaults
+
 Capital pools that automatically generate yield based on opportunities present in the market. Vaults benefit users by socializing gas costs, automating the yield generation and rebalancing process, and automatically shifting capital as opportunities arise. End users also do not need to have a proficient knowledge of the underlying protocols involved or DeFi, thus the Vaults represent a passive-investing strategy.
 
 ### Earn
-The first Yearn product was a lending aggregator. Funds are shifted between dYdX, AAVE, and Compound automatically as interest rates change between these protocols. Users can deposit to these lending aggregator smart contracts via the Earn page. This product completely optimizes the interest accrual process for end-users to ensure they are obtaining the highest interest rates at all times among the platforms specified above. 
+
+The first Yearn product was a lending aggregator. Funds are shifted between dYdX, AAVE, and Compound automatically as interest rates change between these protocols. Users can deposit to these lending aggregator smart contracts via the Earn page. This product completely optimizes the interest accrual process for end-users to ensure they are obtaining the highest interest rates at all times among the platforms specified above.
 
 ### Zap
-A tool that enables users to swap into and out of (known as "Zapping") several liquidity pools available on Curve.Finance. These pools benefit from the lending aggregators discussed above, as well as earning users trading fees by partcipating as Liquidity Providers (LPs) on Curve.Fi. Currently users can use five stablecoins (BUSD, DAI, USDC, USDT, TUSD) and "Zap" into one of two pools (y.curve.fi or busd.curve.f) on Curve. Alternatively, users can "Zap" out of these two Curve pools and into one of the five base stablecoins. 
+
+A tool that enables users to swap into and out of (known as "Zapping") several liquidity pools available on Curve.Finance. These pools benefit from the lending aggregators discussed above, as well as earning users trading fees by partcipating as Liquidity Providers (LPs) on Curve.Fi. Currently users can use five stablecoins (BUSD, DAI, USDC, USDT, TUSD) and "Zap" into one of two pools (y.curve.fi or busd.curve.f) on Curve. Alternatively, users can "Zap" out of these two Curve pools and into one of the five base stablecoins.
 
 ### Cover
-Insurance that enables users to obtain coverage against financial loss for various smart contracts and/or protcols on the Ethereum blockchain. Cover is underwritten by Nexus Mutual. 
+
+Insurance that enables users to obtain coverage against financial loss for various smart contracts and/or protcols on the Ethereum blockchain. Cover is underwritten by Nexus Mutual.
 
 ## Governance
+
 The Yearn ecosystem is controlled by YFI token holders who submit and vote on proposals that govern the ecosystem. Proposals that meet quorum requirements \(&gt;20% of the tokens staked in the governance contract\) and generate a majority support \(&gt;50% of the vote\) are implemented by a 9 member multi-signature wallet. Changes must be signed by 6 out of the 9 wallet signers in order to be implemented. The members of the muliti-signature wallet were voted in by YFI holders and are subject to change from future governance votes. Please refer to our FAQ for [the list of the multisig signers](https://docs.yearn.finance/faq#who-are-the-9-multisig-signers).
 
 ## Communication Channels
+
 Governance Forum [https://gov.yearn.finance/](https://gov.yearn.finance/)
 
 Discord [http://discord.yearn.finance](http://discord.yearn.finance)


### PR DESCRIPTION
Action: Update the Introduction page of the docs. 

The rest of the docs are informative, clear, and detailed providing information about Yearn Finance. The introduction page is sparse, at times inaccurate, and overall disorganized. This PR improves and corrects a few errors on the original docs page.

For example, under the Earn section it states that it is "money markets that serve as building blocks for yVaults". This is incorrect. Earn v1 of Yearn Finance and only represents the optimized interest aggregation pools. They have nothing to do with yVaults. This description has confused the yDAI interest aggregator (Earn product) with the yDAI (yVault product). They are unrelated. 

Under the Zap section, it specifies that users can swap between stablecoins. This is also incorrect. Using this tool users can only "zap" into one of two pools on curve, they cannot swap between stablecoins. 

Additionally, there is some unprofessional and confusing language used throughout the initial docs. For example, "yield robots". What are "yield-robots"? Imagine someone knows nothing DeFi or Yearn and reads about a "yield-robot"? This revised introduction page more articulately explains the products and does not use such terms that more likely will confuse uninformed users even more. 