### PR TITLE
Update output tokens for yvWETH and yvDAI

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -42,15 +42,14 @@
   - [How to Understand yVault ROI](resources/guides/how-to-understand-yvault-roi.md)
   - [How to Understand yveCRV](resources/guides/how-to-understand-yvecrv.md)
 - [Risks](resources/risks/README.md)
-    - [Protocol Risks](resources/risks/protocol-risks.md)
-    - [Strategy Risks](resources/risks/strategy-risks.md)
-    - [Vault Risks](resources/risks/vault-risks.md)
+  - [Protocol Risks](resources/risks/protocol-risks.md)
+  - [Strategy Risks](resources/risks/strategy-risks.md)
+  - [Vault Risks](resources/risks/vault-risks.md)
 - [Links](resources/links.md)
 - [Security Audits](resources/audits.md)
 - [Financials](resources/financials.md)
 - [FAQ](resources/faq.md)
 - [DeFi Glossary](resources/defi-glossary.md)
-
 
 ## Developers
 

--- a/using-yearn.md
+++ b/using-yearn.md
@@ -1,20 +1,20 @@
-# Using Yearn       
+# Using Yearn
 
-Thanks to a feature called 'zap', it's extremely easy to deposit into any vault with almost any token. 
+Thanks to a feature called 'zap', it's extremely easy to deposit into any vault with almost any token.
 
-Here's how it works: 
+Here's how it works:
 
-First, **Connect your wallet** using the button at the top right corner. Multiple types of wallets are supported, but most people use [MetaMask](https://metamask.io/), which can be downloaded for free as a Chrome extension or through the Apple and Android app stores. Make sure that your wallet is connected to the Ethereum network. 
+First, **Connect your wallet** using the button at the top right corner. Multiple types of wallets are supported, but most people use [MetaMask](https://metamask.io/), which can be downloaded for free as a Chrome extension or through the Apple and Android app stores. Make sure that your wallet is connected to the Ethereum network.
 
 <p align="center">
   <img width="1266.75" height="345.75" src="https://i.imgur.com/H0Uc8e8.png">
 </p>
 
-## If you **already have the required token** for the vault that you would like to deposit in: 
+## If you **already have the required token** for the vault that you would like to deposit in:
 
 1\. Select the vault that you would like to deposit into.
 
-2\. Enter the amount of tokens you want to deposit into the vault. If you are depositing ETH, make sure you have enough ETH left over to pay for future transactions that you might need to make. 
+2\. Enter the amount of tokens you want to deposit into the vault. If you are depositing ETH, make sure you have enough ETH left over to pay for future transactions that you might need to make.
 
 <p align="center">
   <img width="914.26" height="360.75" src="https://i.imgur.com/LGdRAMQ.png">
@@ -34,7 +34,7 @@ First, **Connect your wallet** using the button at the top right corner. Multipl
   <img width="928.5" height="93.75" src="https://i.imgur.com/JvNQ3l2.png">
 </p>
 
-When you're ready to withdraw: 
+When you're ready to withdraw:
 
 1\. Select the vault that you would like to withdraw from.
 
@@ -52,9 +52,9 @@ When you're ready to withdraw:
 
 ## If you **don't have the required token** for the vault that you would like to deposit in:
 
-This can be a common occurrence, because many of Yearn's vaults generate yield by using [Curve Finance](http://curve.finance/) liquidity provider (LP) tokens, which are acquired through depositing into a Curve pool. 
+This can be a common occurrence, because many of Yearn's vaults generate yield by using [Curve Finance](http://curve.finance/) liquidity provider (LP) tokens, which are acquired through depositing into a Curve pool.
 
-So for instance, if you would rather deposit into the crvSTETH vault instead of the ETH vault, and accept the additional risk that comes with the curve pool and an ETH derivative (stETH) in return for higher yield, but you only have ETH in your wallet, your ETH will need to be converted to a crvSTETH token before it is accepted in the vault. 
+So for instance, if you would rather deposit into the crvSTETH vault instead of the ETH vault, and accept the additional risk that comes with the curve pool and an ETH derivative (stETH) in return for higher yield, but you only have ETH in your wallet, your ETH will need to be converted to a crvSTETH token before it is accepted in the vault.
 
 Thankfully, due to Yearn's 'zap' feature, this can all be done in the same transaction as your deposit. Here's how it works using the crvSTETH vault as an example:
 
@@ -70,13 +70,13 @@ Thankfully, due to Yearn's 'zap' feature, this can all be done in the same trans
   <img width="909" height="363" src="https://i.imgur.com/6K1luO7.png">
 </p>
 
-4\. Enter the amount of tokens you would like to deposit and click 'Approve' or 'Deposit' depending on whether or not you have previously approved the token. 
+4\. Enter the amount of tokens you would like to deposit and click 'Approve' or 'Deposit' depending on whether or not you have previously approved the token.
 
 5\. Confirm the transaction through your wallet. See step 4 in the section above for more details.
 
 6\. When your transaction succeeds, you will see your deposited balance in the vault's interface, which should appear at the top of the vault list.
 
-When you're ready to withdraw: 
+When you're ready to withdraw:
 
 1\. Select the crvSTETH vault.
 
@@ -94,11 +94,11 @@ When you're ready to withdraw:
 
 6\. When your transaction succeeds, the tokens will show up in your wallet again.
 
-## Tools to track your funds 
+## Tools to track your funds
 
-If you would like to see how your USD balance changes while your assets are in a vault, connect your wallet to [zapper.fi](https://zapper.fi) or a similar portfolio tracking product.This is also the easiest way to tell how much profit the vault has made for you. 
+If you would like to see how your USD balance changes while your assets are in a vault, connect your wallet to [zapper.fi](https://zapper.fi) or a similar portfolio tracking product.This is also the easiest way to tell how much profit the vault has made for you.
 
-Your balance WILL NOT increase continuously. Profit will be distributed to your share of the vault when the harvest() function is called, which happens on a fluctuating basis. 
+Your balance WILL NOT increase continuously. Profit will be distributed to your share of the vault when the harvest() function is called, which happens on a fluctuating basis.
 
 Community resources to monitor your returns:
 

--- a/yearn-finance/yvaults/vault-tokens.md
+++ b/yearn-finance/yvaults/vault-tokens.md
@@ -21,8 +21,8 @@ Once a user's liquidity is withdrawn from the yVault, their yVault Token will be
 | WETH | [WETH](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [yvWETH](https://etherscan.io/address/0xa258C4606Ca8206D8aA700cE2143D7db854D168c) |
 | USDC | [USDC](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) | [yvUSDC](https://etherscan.io/token/0x5f18c75abdae578b483e5f43f12a39cf75b973a9) |
 | HEGIC | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) |
-| DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/address/0xdA816459F1AB5631232FE5e97a05BBBb94970c95) |
-| WBTC | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
+| DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/token/0xdA816459F1AB5631232FE5e97a05BBBb94970c95) |
+| WBTC | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [WBTC yVault](https://etherscan.io/token/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
 | USDT | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [yvUDST](https://etherscan.io/token/0x7Da96a3891Add058AdA2E826306D812C638D87a7) |
 | crvIB | [Curve Iron Bank Pool yVault](https://etherscan.io/address/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) | [yCurve-IronBank](https://etherscan.io/token/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) |
 | crvSETH | [Curve sETH Pool yVault](https://etherscan.io/address/0x986b4AFF588a109c09B50A03f42E4110E29D353F) | [yvCurve-sETH](https://etherscan.io/token/0x986b4AFF588a109c09B50A03f42E4110E29D353F) |

--- a/yearn-finance/yvaults/vault-tokens.md
+++ b/yearn-finance/yvaults/vault-tokens.md
@@ -22,21 +22,21 @@ Once a user's liquidity is withdrawn from the yVault, their yVault Token will be
 | USDC | [USDC](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) | [yvUSDC](https://etherscan.io/token/0x5f18c75abdae578b483e5f43f12a39cf75b973a9) |
 | HEGIC | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) |
 | DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/token/0xdA816459F1AB5631232FE5e97a05BBBb94970c95) |
-| WBTC | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [WBTC yVault](https://etherscan.io/token/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
-| USDT | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [yvUDST](https://etherscan.io/token/0x7Da96a3891Add058AdA2E826306D812C638D87a7) |
-| crvIB | [Curve Iron Bank Pool yVault](https://etherscan.io/address/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) | [yCurve-IronBank](https://etherscan.io/token/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) |
-| crvSETH | [Curve sETH Pool yVault](https://etherscan.io/address/0x986b4AFF588a109c09B50A03f42E4110E29D353F) | [yvCurve-sETH](https://etherscan.io/token/0x986b4AFF588a109c09B50A03f42E4110E29D353F) |
-| crvstETH | [Curve stETH Pool yVault](https://etherscan.io/address/0xdcd90c7f6324cfa40d7169ef80b12031770b4325) | [yvCurve-stETH](https://etherscan.io/token/0xdcd90c7f6324cfa40d7169ef80b12031770b4325) |
-| crvSBTC | [Curve sBTC Pool yVault](https://etherscan.io/address/0x8414Db07a7F743dEbaFb402070AB01a4E0d2E45e) | [yvCurve-sBTC](https://etherscan.io/token/0x8414Db07a7F743dEbaFb402070AB01a4E0d2E45e) |
-| crvRENBTC | [Curve renBTC Pool yVault](https://etherscan.io/address/0x7047F90229a057C13BF847C0744D646CFb6c9E1A) | [yvCurve-renBTC](https://etherscan.io/token/0x7047F90229a057C13BF847C0744D646CFb6c9E1A) |
-| crvOBTC | [Curve oBTC Pool yVault](https://etherscan.io/address/0xe9Dc63083c464d6EDcCFf23444fF3CFc6886f6FB) | [yvCurve-oBTC](https://etherscan.io/token/0xe9Dc63083c464d6EDcCFf23444fF3CFc6886f6FB) |
-| crvPBTC | [Curve pBTC Pool yVault](https://etherscan.io/address/0x3c5DF3077BcF800640B5DAE8c91106575a4826E6) | [yvCurve-pBTC](https://etherscan.io/token/0x3c5DF3077BcF800640B5DAE8c91106575a4826E6) | 
-| crvTBTC | [Curve tBTC Pool yVaut](https://etherscan.io/address/0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f) | [yvCurve-tBTC](https://etherscan.io/token/0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f) | 
-| crvFRAX | [Curve FRAX Pool yVault](https://etherscan.io/address/0xB4AdA607B9d6b2c9Ee07A275e9616B84AC560139#code) | [yvCurve-FRAX](https://etherscan.io/token/0xB4AdA607B9d6b2c9Ee07A275e9616B84AC560139) | 
-| crvLUSD | [Curve LUSD Pool yVault](https://etherscan.io/address/0x5fA5B62c8AF877CB37031e0a3B2f34A78e3C56A6#code) | [yvCurve-LUSD](https://etherscan.io/token/0x5fA5B62c8AF877CB37031e0a3B2f34A78e3C56A6) | 
-| crvSAAVE | [Curve sAave Pool yVault](https://etherscan.io/address/0xb4D1Be44BfF40ad6e506edf43156577a3f8672eC#code) | [yvCurve-sAave](https://etherscan.io/token/0xb4D1Be44BfF40ad6e506edf43156577a3f8672eC) | 
-| crvBBTC | [Curve BBTC Pool yVault](https://etherscan.io/address/0x8fA3A9ecd9EFb07A8CE90A6eb014CF3c0E3B32Ef) | [yvCurve-BBTC](https://etherscan.io/token/0x8fA3A9ecd9EFb07A8CE90A6eb014CF3c0E3B32Ef) | 
-| yvBOOST | [Yearn Compounding veCRV yVault](https://etherscan.io/address/0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a) | [yvBOOST](https://etherscan.io/token/0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a) | 
+| WBTC | [WBTC](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [WBTC yVault](https://etherscan.io/token/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
+| USDT | [USDT](https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7) | [yvUDST](https://etherscan.io/token/0x7Da96a3891Add058AdA2E826306D812C638D87a7) |
+| crvIB | [Curve Iron Bank Pool](https://etherscan.io/token/0x5282a4ef67d9c33135340fb3289cc1711c13638c) | [yCurve-IronBank](https://etherscan.io/token/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) |
+| crvSETH | [Curve sETH Pool](https://etherscan.io/token/0xa3d87fffce63b53e0d54faa1cc983b7eb0b74a9c) | [yvCurve-sETH](https://etherscan.io/token/0x986b4AFF588a109c09B50A03f42E4110E29D353F) |
+| crvstETH | [Curve stETH Pool](https://etherscan.io/token/0x06325440d014e39736583c165c2963ba99faf14e) | [yvCurve-stETH](https://etherscan.io/token/0xdcd90c7f6324cfa40d7169ef80b12031770b4325) |
+| crvSBTC | [Curve sBTC Pool](https://etherscan.io/token/0x075b1bb99792c9e1041ba13afef80c91a1e70fb3) | [yvCurve-sBTC](https://etherscan.io/token/0x8414Db07a7F743dEbaFb402070AB01a4E0d2E45e) |
+| crvRENBTC | [Curve renBTC Pool](https://etherscan.io/token/0x49849c98ae39fff122806c06791fa73784fb3675) | [yvCurve-renBTC](https://etherscan.io/token/0x7047F90229a057C13BF847C0744D646CFb6c9E1A) |
+| crvOBTC | [Curve oBTC Pool](https://etherscan.io/token/0x2fe94ea3d5d4a175184081439753de15aef9d614) | [yvCurve-oBTC](https://etherscan.io/token/0xe9Dc63083c464d6EDcCFf23444fF3CFc6886f6FB) |
+| crvPBTC | [Curve pBTC Pool](https://etherscan.io/token/0xde5331ac4b3630f94853ff322b66407e0d6331e8) | [yvCurve-pBTC](https://etherscan.io/token/0x3c5DF3077BcF800640B5DAE8c91106575a4826E6) | 
+| crvTBTC | [Curve tBTC Pool](https://etherscan.io/token/0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd) | [yvCurve-tBTC](https://etherscan.io/token/0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f) | 
+| crvFRAX | [Curve FRAX Pool](https://etherscan.io/token/0xd632f22692fac7611d2aa1c0d552930d43caed3b) | [yvCurve-FRAX](https://etherscan.io/token/0xB4AdA607B9d6b2c9Ee07A275e9616B84AC560139) | 
+| crvLUSD | [Curve LUSD Pool](https://etherscan.io/token/0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca) | [yvCurve-LUSD](https://etherscan.io/token/0x5fA5B62c8AF877CB37031e0a3B2f34A78e3C56A6) | 
+| crvSAAVE | [Curve sAave Pool](https://etherscan.io/token/0x02d341ccb60faaf662bc0554d13778015d1b285c) | [yvCurve-sAave](https://etherscan.io/token/0xb4D1Be44BfF40ad6e506edf43156577a3f8672eC) | 
+| crvBBTC | [Curve BBTC Pool](https://etherscan.io/token/0x410e3e86ef427e30b9235497143881f717d93c2a) | [yvCurve-BBTC](https://etherscan.io/token/0x8fA3A9ecd9EFb07A8CE90A6eb014CF3c0E3B32Ef) | 
+| yvBOOST | [Yearn Compounding veCRV](https://etherscan.io/token/0xc5bddf9843308380375a611c18b50fb9341f502a) | [yvBOOST](https://etherscan.io/token/0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a) | 
 
 ## V1 yVault Tokens
 
@@ -48,7 +48,7 @@ Once a user's liquidity is withdrawn from the yVault, their yVault Token will be
 | yCRV\(yUSD\) | [yDAI+yUSDC+yUSDT+yTUSD](https://etherscan.io/token/0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8) | [yyDAI+yUSDC+yUSDT+yTUSD](https://etherscan.io/token/0x5dbcf33d8c2e976c6b560249878e6f1491bca25c) |
 | crvMUSD | [musd3CRV](https://etherscan.io/token/0x1AEf73d49Dedc4b1778d0706583995958Dc862e6) | [yvmusd3CRV](https://etherscan.io/token/0x0FCDAeDFb8A7DfDa2e9838564c5A1665d856AFDF) |
 | crvGUSD | [gusd3CRV](https://etherscan.io/token/0xD2967f45c4f384DEEa880F807Be904762a3DeA07) | [yvgusd3CRV](https://etherscan.io/token/0xcC7E70A958917cCe67B4B87a8C30E6297451aE98) |
-| crvDUSD | [dusd3CRV](https://etherscan.io/token/0x3a664Ab939FD8482048609f652f9a0B0677337B9) | [yvdusd3CRV](https://etherscan.io/address/0x8e6741b456a074F0Bc45B8b82A755d4aF7E965dF#code) |
+| crvDUSD | [dusd3CRV](https://etherscan.io/token/0x3a664Ab939FD8482048609f652f9a0B0677337B9) | [yvdusd3CRV](https://etherscan.io/token/0x8e6741b456a074F0Bc45B8b82A755d4aF7E965dF) |
 | crvUSDN | [usdn3CRV](https://etherscan.io/token/0x4f3E8F405CF5aFC05D68142F3783bDfE13811522) | [yvusdn3CRV](https://etherscan.io/token/0xFe39Ce91437C76178665D64d7a2694B0f6f17fE3) |
 | crvUSDT | [ust3CRV](https://etherscan.io/token/0x94e131324b6054c0D789b190b2dAC504e4361b53) | [yvusdt3CRV](https://etherscan.io/token/0xF6C9E9AF314982A4b38366f4AbfAa00595C5A6fC) |
 | crvHUSD | [husd3CRV](https://etherscan.io/token/0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858) | [yvhusd3CRV](https://etherscan.io/token/0x39546945695DCb1c037C836925B355262f551f55) |

--- a/yearn-finance/yvaults/vault-tokens.md
+++ b/yearn-finance/yvaults/vault-tokens.md
@@ -18,10 +18,10 @@ Once a user's liquidity is withdrawn from the yVault, their yVault Token will be
 | :--- | :--- | :--- | 
 | YFI | [YFI](https://etherscan.io/token/0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e) | [yvYFI](https://etherscan.io/token/0xE14d13d8B3b85aF791b2AADD661cDBd5E6097Db1) |
 | 1INCH | [1INCH](https://etherscan.io/token/0x111111111117dc0aa78b770fa6a738034120c302) | [yv1INCH](https://etherscan.io/token/0xB8C3B7A2A618C552C23B1E4701109a9E756Bab67) |
-| WETH | [WETH](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [yvWETH](https://etherscan.io/token/0xa9fE4601811213c340e850ea305481afF02f5b28) |
+| WETH | [WETH](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [yvWETH](https://etherscan.io/address/0xa258C4606Ca8206D8aA700cE2143D7db854D168c) |
 | USDC | [USDC](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) | [yvUSDC](https://etherscan.io/token/0x5f18c75abdae578b483e5f43f12a39cf75b973a9) |
 | HEGIC | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) |
-| DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/token/0x19d3364a399d251e894ac732651be8b0e4e85001) |
+| DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/address/0xdA816459F1AB5631232FE5e97a05BBBb94970c95) |
 | WBTC | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
 | USDT | [WBTC yVault](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [yvUDST](https://etherscan.io/token/0x7Da96a3891Add058AdA2E826306D812C638D87a7) |
 | crvIB | [Curve Iron Bank Pool yVault](https://etherscan.io/address/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) | [yCurve-IronBank](https://etherscan.io/token/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) |

--- a/yearn-finance/yvaults/vault-tokens.md
+++ b/yearn-finance/yvaults/vault-tokens.md
@@ -18,7 +18,7 @@ Once a user's liquidity is withdrawn from the yVault, their yVault Token will be
 | :--- | :--- | :--- | 
 | YFI | [YFI](https://etherscan.io/token/0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e) | [yvYFI](https://etherscan.io/token/0xE14d13d8B3b85aF791b2AADD661cDBd5E6097Db1) |
 | 1INCH | [1INCH](https://etherscan.io/token/0x111111111117dc0aa78b770fa6a738034120c302) | [yv1INCH](https://etherscan.io/token/0xB8C3B7A2A618C552C23B1E4701109a9E756Bab67) |
-| WETH | [WETH](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [yvWETH](https://etherscan.io/address/0xa258C4606Ca8206D8aA700cE2143D7db854D168c) |
+| WETH | [WETH](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [yvWETH](https://etherscan.io/token/0xa258C4606Ca8206D8aA700cE2143D7db854D168c) |
 | USDC | [USDC](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) | [yvUSDC](https://etherscan.io/token/0x5f18c75abdae578b483e5f43f12a39cf75b973a9) |
 | HEGIC | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) |
 | DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/token/0xdA816459F1AB5631232FE5e97a05BBBb94970c95) |

--- a/yearn-finance/yvaults/vault-tokens.md
+++ b/yearn-finance/yvaults/vault-tokens.md
@@ -22,7 +22,7 @@ Once a user's liquidity is withdrawn from the yVault, their yVault Token will be
 | USDC | [USDC](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) | [yvUSDC](https://etherscan.io/token/0x5f18c75abdae578b483e5f43f12a39cf75b973a9) |
 | HEGIC | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) | [HEGIC](https://etherscan.io/token/0x584bC13c7D411c00c01A62e8019472dE68768430) |
 | DAI | [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) | [yvDAI](https://etherscan.io/token/0xdA816459F1AB5631232FE5e97a05BBBb94970c95) |
-| WBTC | [WBTC](https://etherscan.io/address/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) | [WBTC yVault](https://etherscan.io/token/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
+| WBTC | [WBTC](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599) | [WBTC yVault](https://etherscan.io/token/0xcb550a6d4c8e3517a939bc79d0c7093eb7cf56b5) |
 | USDT | [USDT](https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7) | [yvUDST](https://etherscan.io/token/0x7Da96a3891Add058AdA2E826306D812C638D87a7) |
 | crvIB | [Curve Iron Bank Pool](https://etherscan.io/token/0x5282a4ef67d9c33135340fb3289cc1711c13638c) | [yCurve-IronBank](https://etherscan.io/token/0x27b7b1ad7288079A66d12350c828D3C00A6F07d7) |
 | crvSETH | [Curve sETH Pool](https://etherscan.io/token/0xa3d87fffce63b53e0d54faa1cc983b7eb0b74a9c) | [yvCurve-sETH](https://etherscan.io/token/0x986b4AFF588a109c09B50A03f42E4110E29D353F) |


### PR DESCRIPTION
yvWETH and yvDAI vaults were migrated to newer versions of the vault code hence the contract addresses of those tokens changed.